### PR TITLE
Updates for Xcode 13.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,10 @@ on:
 
 jobs:
   macos:
-    name: macOS 10.15 tests
-    runs-on: macos-latest
+    name: Tests
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: Tests


### PR DESCRIPTION
Should probably update min deployment levels at some point, macOS 10.12 long-gone EOL.